### PR TITLE
Render only visible area of color function on Background color canvas

### DIFF
--- a/examples/basic/main.ts
+++ b/examples/basic/main.ts
@@ -21,6 +21,14 @@ if (editorHome) {
     [0.6, 0.2],
     [1, 1],
   ])
+
+  editor.setHistogram([0.1, 0.2, 0.2, 0.5, 0.4, 0.1])
+
+  editor.setColorTransferFunction({
+    getMappingRange: () => [0, 10],
+    getUint8Table: () => new Uint8Array([255, 255, 255, 255]),
+  })
+
   // eslint-disable-next-line no-console
   console.log('Control points', editor.getPoints())
   globalThis.editor = editor

--- a/examples/itk-vtk-viewer/createTransferFunctionEditor.js
+++ b/examples/itk-vtk-viewer/createTransferFunctionEditor.js
@@ -2,11 +2,11 @@ import { throttle } from '@kitware/vtk.js/macros'
 import {
   TransferFunctionEditor,
   windowPointsForSort,
-} from 'itk-viewer-transfer-function-editor.js'
+} from 'itk-viewer-transfer-function-editor'
 
 const PIECEWISE_UPDATE_DELAY = 100
 
-const getNodes = (range, points) => {
+export const getNodes = (range, points) => {
   const delta = range[1] - range[0]
   const windowedPoints = windowPointsForSort(points)
   return windowedPoints.map(([x, y]) => ({
@@ -38,7 +38,6 @@ const updateContextPiecewiseFunction = (context, dataRange, points) => {
 
   const nodes = getNodes(dataRange, points)
   const range = getRange(dataRange, nodes)
-
   context.service.send({
     type: 'IMAGE_PIECEWISE_FUNCTION_CHANGED',
     data: {
@@ -59,17 +58,11 @@ const vtkPiecewiseGaussianWidgetFacade = (tfEditor, context) => {
   const throttledUpdate = throttle(update, PIECEWISE_UPDATE_DELAY)
   tfEditor.eventTarget.addEventListener('updated', throttledUpdate)
 
-  const getOpacityNodes = (tempDataRange) =>
-    getNodes(tempDataRange ?? dataRange, tfEditor.getPoints())
+  const getOpacityNodes = (range = dataRange) =>
+    getNodes(range, tfEditor.getPoints())
 
-  const getOpacityRange = (tempDataRange) =>
-    getRange(
-      tempDataRange ?? dataRange,
-      getOpacityNodes(tempDataRange ?? dataRange)
-    )
-
-  // to compare changes across setting the data view range
-  let cachedGaussian
+  const getOpacityRange = (range = dataRange) =>
+    getRange(range, getOpacityNodes(range))
 
   return {
     setColorTransferFunction: (tf) => {
@@ -78,42 +71,7 @@ const vtkPiecewiseGaussianWidgetFacade = (tfEditor, context) => {
 
     setPoints(points) {
       tfEditor.setPoints(points)
-    },
-
-    getGaussians() {
-      const xPositions = tfEditor.getPoints().map(([x]) => x)
-      const min = Math.min(...xPositions)
-      const width = (Math.max(...xPositions) - min) / 2 || 0.5 // if one point, fill width
-      const position = min + width
-      const height = Math.max(...tfEditor.getPoints().map(([, y]) => y))
-
-      return [{ width, position, height }]
-    },
-
-    setGaussians(gaussians) {
-      const newG = gaussians[0]
-      const oldG = cachedGaussian ?? this.getGaussians()[0]
-      const heightDelta = newG.height - oldG.height
-
-      const newMin = newG.position - newG.width
-      const newRange = 2 * newG.width
-
-      const pointsGaussian = this.getGaussians()[0]
-      const pointsMin = pointsGaussian.position - pointsGaussian.width
-      const points = tfEditor
-        .getPoints()
-        // compute x in "gaussian" space
-        .map(([x, y]) => [(x - pointsMin) / (pointsGaussian.width * 2), y])
-        // rescale points into new gaussian range
-        .map(([x, y]) => {
-          return [x * newRange + newMin, y + y * heightDelta]
-        })
-
-      tfEditor.setPoints(points)
-
-      cachedGaussian = { ...newG }
-
-      update()
+      updateContextPiecewiseFunction(context, dataRange, points)
     },
 
     getPoints() {
@@ -132,6 +90,15 @@ const vtkPiecewiseGaussianWidgetFacade = (tfEditor, context) => {
     getOpacityRange,
     setHistogram: (h) => tfEditor.setHistogram(h),
     render: () => undefined,
+
+    getGaussians() {
+      console.warn('getGaussians not implemented, use getPoints')
+      return []
+    },
+
+    setGaussians() {
+      console.warn('setGaussians not implemented, use setPoints')
+    },
   }
 }
 

--- a/examples/itk-vtk-viewer/createTransferFunctionEditor.js
+++ b/examples/itk-vtk-viewer/createTransferFunctionEditor.js
@@ -2,7 +2,7 @@ import { throttle } from '@kitware/vtk.js/macros'
 import {
   TransferFunctionEditor,
   windowPointsForSort,
-} from 'itk-viewer-transfer-function-editor'
+} from 'itk-viewer-transfer-function-editor.js'
 
 const PIECEWISE_UPDATE_DELAY = 100
 

--- a/examples/itk-vtk-viewer/createTransferFunctionWidget.js
+++ b/examples/itk-vtk-viewer/createTransferFunctionWidget.js
@@ -1,16 +1,16 @@
 import vtkMouseRangeManipulator from '@kitware/vtk.js/Interaction/Manipulators/MouseRangeManipulator'
-
 import { createTransferFunctionEditor } from './createTransferFunctionEditor'
+// import style from '../ItkVtkViewer.module.css'
 
 const MIN_WIDTH = 1e-8
 
-const createTransferFunctionWidget = (context, imagesUIGroup, style) => {
+const createTransferFunctionWidget = (context, imagesUIGroup) => {
   const piecewiseWidgetContainer = document.createElement('div')
   piecewiseWidgetContainer.setAttribute('style', 'height: 150px; width: 400px')
-  piecewiseWidgetContainer.setAttribute('class', style.piecewiseWidget)
+  // piecewiseWidgetContainer.setAttribute('class', style.piecewiseWidget)
 
   const transferFunctionWidgetRow = document.createElement('div')
-  transferFunctionWidgetRow.setAttribute('class', style.uiRow)
+  // transferFunctionWidgetRow.setAttribute('class', style.uiRow)
   // This row needs background different from normal uiRows, to aid
   // in the illusion that it's the content portion of a tabbed pane
   transferFunctionWidgetRow.setAttribute(
@@ -103,7 +103,7 @@ const createTransferFunctionWidget = (context, imagesUIGroup, style) => {
     const delta = newMaxOpacity - oldMax
     const newPoints = transferFunctionWidget
       .getPoints()
-      .map(([x, y]) => [x, y + delta])
+      .map(([x, y]) => [x, Math.min(y + delta, 1)])
     transferFunctionWidget.setPoints(newPoints)
   }
   // max as 1.01 not 1.0 to allow for squishing of low function points if a point is already at 1
@@ -118,3 +118,12 @@ const createTransferFunctionWidget = (context, imagesUIGroup, style) => {
 }
 
 export default createTransferFunctionWidget
+
+export const applyPiecewiseFunctionPointsToEditor = (context, event) => {
+  const { transferFunctionWidget, actorContext } = context.images
+  const { points, component, name } = event.data
+  const imageActorContext = actorContext.get(name)
+  if (component === imageActorContext.selectedComponent) {
+    transferFunctionWidget.setPoints(points)
+  }
+}

--- a/examples/itk-vtk-viewer/package-lock.json
+++ b/examples/itk-vtk-viewer/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@kitware/vtk.js": "^19.0.2",
-        "itk-vtk-viewer": "^14.2.1"
+        "itk-vtk-viewer": "^14.9.1"
       },
       "devDependencies": {
         "@babel/core": "^7.14.8",
@@ -1547,6 +1547,11 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
+    "node_modules/fflate": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.3.tgz",
+      "integrity": "sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw=="
+    },
     "node_modules/finalhandler": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
@@ -2121,12 +2126,17 @@
       "resolved": "https://registry.npmjs.org/itk-viewer-icons/-/itk-viewer-icons-11.12.0.tgz",
       "integrity": "sha512-Utd13l7zQbgPmc7OPFdNLAblv/PHx0kN1mSt0bvPnWYWqDFs6BQF2uY5JxtGrJk6tfjgNYb2NT1uHCwYY2YQRQ=="
     },
+    "node_modules/itk-viewer-transfer-function-editor": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/itk-viewer-transfer-function-editor/-/itk-viewer-transfer-function-editor-1.1.2.tgz",
+      "integrity": "sha512-GKutwT/6f/y2zPVqIOgzkvSt7L1u4yjOWyFwq7dm+8oDUis5yK5QTOnSG3n9WewIdQQh8NqcBR7vXJEcWDeZ5A=="
+    },
     "node_modules/itk-vtk-viewer": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/itk-vtk-viewer/-/itk-vtk-viewer-14.2.1.tgz",
-      "integrity": "sha512-c4gL31fiPBminlG9vJZzeyVJBEeJcGl7nvidcDhnGAlKm75Z7Df+4Q2mXHrrF909eKtxHFfw+FqF5cEkM7DDVQ==",
+      "version": "14.9.1",
+      "resolved": "https://registry.npmjs.org/itk-vtk-viewer/-/itk-vtk-viewer-14.9.1.tgz",
+      "integrity": "sha512-Y6VI/ozojoI7LXDr9Lbf59VrMPTP6tykJhv7WLyRZ/sKqcanw+9L1kHtDlMQUpTyT0lrZTVpuNSdO0PGYJZE2g==",
       "dependencies": {
-        "@kitware/vtk.js": "^24.14.2",
+        "@kitware/vtk.js": "^25.2.4",
         "@thewtex/iconselect.js": "^2.1.2",
         "@xstate/inspect": "^0.4.1",
         "axios": "^0.21.1",
@@ -2135,9 +2145,11 @@
         "curry": "^1.2.0",
         "eventemitter3": "^4.0.7",
         "express": "^4.17.1",
+        "gl-matrix": "^3.4.3",
         "itk-image-io": "^1.0.0-b.15",
         "itk-mesh-io": "^1.0.0-b.15",
         "itk-viewer-icons": "^11.12.0",
+        "itk-viewer-transfer-function-editor": "^1.1.2",
         "itk-wasm": "^1.0.0-b.17",
         "mobx": "^5.15.7",
         "mousetrap": "^1.6.5",
@@ -2145,7 +2157,7 @@
         "promise-file-reader": "^1.0.3",
         "promise.any": "^2.0.2",
         "regenerator-runtime": "^0.13.7",
-        "vtk.js": "^24.14.2",
+        "vtk.js": "^25.2.4",
         "webworker-promise": "^0.4.2",
         "xstate": "^4.16.2"
       },
@@ -2165,21 +2177,20 @@
       }
     },
     "node_modules/itk-vtk-viewer/node_modules/@kitware/vtk.js": {
-      "version": "24.19.1",
-      "resolved": "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-24.19.1.tgz",
-      "integrity": "sha512-vaFT4ynXJrM+7v3/q0kiYlLj0uxjNIcuoG8+asR6FFX7vzpnkAqH7LXkNgOrwxxNsowFZvA2NTUTzajpE3h5uQ==",
+      "version": "25.7.2",
+      "resolved": "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-25.7.2.tgz",
+      "integrity": "sha512-ZobyH3vah846Vz2k3BaeUtmKKMEW8e8eddCkwYXSqp8Cv0OaZW/m4SFD6mmghJuUvgaqlqqoHPxIdavdts9g6A==",
       "dependencies": {
         "@babel/runtime": "7.17.9",
         "commander": "9.2.0",
         "d3-scale": "4.0.2",
+        "fflate": "0.7.3",
         "gl-matrix": "3.4.3",
         "globalthis": "1.0.3",
-        "jszip": "3.9.1",
-        "pako": "2.0.4",
         "seedrandom": "3.0.5",
         "shader-loader": "1.3.1",
         "shelljs": "0.8.5",
-        "spark-md5": "^3.0.2",
+        "spark-md5": "3.0.2",
         "stream-browserify": "3.0.0",
         "webworker-promise": "0.5.0",
         "worker-loader": "3.0.8",
@@ -2259,27 +2270,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/itk-vtk-viewer/node_modules/jszip": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.9.1.tgz",
-      "integrity": "sha512-H9A60xPqJ1CuC4Ka6qxzXZeU8aNmgOeP5IFqwJbQQwtu2EUYxota3LdsiZWplF7Wgd9tkAd0mdu36nceSaPuYw==",
-      "dependencies": {
-        "lie": "~3.3.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.3.6",
-        "set-immediate-shim": "~1.0.1"
-      }
-    },
-    "node_modules/itk-vtk-viewer/node_modules/jszip/node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-    },
-    "node_modules/itk-vtk-viewer/node_modules/pako": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
-      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
-    },
     "node_modules/itk-vtk-viewer/node_modules/shelljs": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
@@ -2297,21 +2287,20 @@
       }
     },
     "node_modules/itk-vtk-viewer/node_modules/vtk.js": {
-      "version": "24.19.1",
-      "resolved": "https://registry.npmjs.org/vtk.js/-/vtk.js-24.19.1.tgz",
-      "integrity": "sha512-1CZF3Z3D3q/PJxIInP7WQQvFngDYAywt2fZZyZfr7y7WQUPfds7dGXk1Z4J4osujdUZjvS0uIBKTo4Qd3u3kZw==",
+      "version": "25.7.2",
+      "resolved": "https://registry.npmjs.org/vtk.js/-/vtk.js-25.7.2.tgz",
+      "integrity": "sha512-p1ztrxdZVa3vH3H++savxYsu5/RO7fWOT1bt76W+c9w6B0MbWoykGT7iqjKeRNcnAIri6S2ZIT3MXwyUWDQnxQ==",
       "dependencies": {
         "@babel/runtime": "7.17.9",
         "commander": "9.2.0",
         "d3-scale": "4.0.2",
+        "fflate": "0.7.3",
         "gl-matrix": "3.4.3",
         "globalthis": "1.0.3",
-        "jszip": "3.9.1",
-        "pako": "2.0.4",
         "seedrandom": "3.0.5",
         "shader-loader": "1.3.1",
         "shelljs": "0.8.5",
-        "spark-md5": "^3.0.2",
+        "spark-md5": "3.0.2",
         "stream-browserify": "3.0.0",
         "webworker-promise": "0.5.0",
         "worker-loader": "3.0.8",
@@ -2339,9 +2328,9 @@
       "integrity": "sha512-14iR79jHAV7ozwvbfif+3wCaApT3I1g8Lo0rJZrwAu6wxZGx/08Y8KXz6as6ZLNUEEufeiEBBYrqyDBClXOsEw=="
     },
     "node_modules/itk-vtk-viewer/node_modules/wslink": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/wslink/-/wslink-1.6.6.tgz",
-      "integrity": "sha512-4gsAnhRBvnfg5uAbk2Q0akwZ4ZQVeDlr97oc/To9kJ3YIxmy4Jh/kMDLzod8+kFvpoj4BbWVr51A9EqlRmknJg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/wslink/-/wslink-1.7.0.tgz",
+      "integrity": "sha512-g+HJvmmZ07+5pfu3cPTl3WPluv0/m0ZQzAMsA+oFu7y7v3j0+NRI1g5YbaAeNBLJv1uppHFp6SOy2Xt+5ohxNA==",
       "peer": true,
       "dependencies": {
         "json5": "2.2.0"
@@ -4848,6 +4837,11 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
+    "fflate": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.3.tgz",
+      "integrity": "sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw=="
+    },
     "finalhandler": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
@@ -5244,12 +5238,17 @@
       "resolved": "https://registry.npmjs.org/itk-viewer-icons/-/itk-viewer-icons-11.12.0.tgz",
       "integrity": "sha512-Utd13l7zQbgPmc7OPFdNLAblv/PHx0kN1mSt0bvPnWYWqDFs6BQF2uY5JxtGrJk6tfjgNYb2NT1uHCwYY2YQRQ=="
     },
+    "itk-viewer-transfer-function-editor": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/itk-viewer-transfer-function-editor/-/itk-viewer-transfer-function-editor-1.1.2.tgz",
+      "integrity": "sha512-GKutwT/6f/y2zPVqIOgzkvSt7L1u4yjOWyFwq7dm+8oDUis5yK5QTOnSG3n9WewIdQQh8NqcBR7vXJEcWDeZ5A=="
+    },
     "itk-vtk-viewer": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/itk-vtk-viewer/-/itk-vtk-viewer-14.2.1.tgz",
-      "integrity": "sha512-c4gL31fiPBminlG9vJZzeyVJBEeJcGl7nvidcDhnGAlKm75Z7Df+4Q2mXHrrF909eKtxHFfw+FqF5cEkM7DDVQ==",
+      "version": "14.9.1",
+      "resolved": "https://registry.npmjs.org/itk-vtk-viewer/-/itk-vtk-viewer-14.9.1.tgz",
+      "integrity": "sha512-Y6VI/ozojoI7LXDr9Lbf59VrMPTP6tykJhv7WLyRZ/sKqcanw+9L1kHtDlMQUpTyT0lrZTVpuNSdO0PGYJZE2g==",
       "requires": {
-        "@kitware/vtk.js": "^24.14.2",
+        "@kitware/vtk.js": "^25.2.4",
         "@thewtex/iconselect.js": "^2.1.2",
         "@xstate/inspect": "^0.4.1",
         "axios": "^0.21.1",
@@ -5258,9 +5257,11 @@
         "curry": "^1.2.0",
         "eventemitter3": "^4.0.7",
         "express": "^4.17.1",
+        "gl-matrix": "^3.4.3",
         "itk-image-io": "^1.0.0-b.15",
         "itk-mesh-io": "^1.0.0-b.15",
         "itk-viewer-icons": "^11.12.0",
+        "itk-viewer-transfer-function-editor": "^1.1.2",
         "itk-wasm": "^1.0.0-b.17",
         "mobx": "^5.15.7",
         "mousetrap": "^1.6.5",
@@ -5268,7 +5269,7 @@
         "promise-file-reader": "^1.0.3",
         "promise.any": "^2.0.2",
         "regenerator-runtime": "^0.13.7",
-        "vtk.js": "^24.14.2",
+        "vtk.js": "^25.2.4",
         "webworker-promise": "^0.4.2",
         "xstate": "^4.16.2"
       },
@@ -5282,21 +5283,20 @@
           }
         },
         "@kitware/vtk.js": {
-          "version": "24.19.1",
-          "resolved": "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-24.19.1.tgz",
-          "integrity": "sha512-vaFT4ynXJrM+7v3/q0kiYlLj0uxjNIcuoG8+asR6FFX7vzpnkAqH7LXkNgOrwxxNsowFZvA2NTUTzajpE3h5uQ==",
+          "version": "25.7.2",
+          "resolved": "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-25.7.2.tgz",
+          "integrity": "sha512-ZobyH3vah846Vz2k3BaeUtmKKMEW8e8eddCkwYXSqp8Cv0OaZW/m4SFD6mmghJuUvgaqlqqoHPxIdavdts9g6A==",
           "requires": {
             "@babel/runtime": "7.17.9",
             "commander": "9.2.0",
             "d3-scale": "4.0.2",
+            "fflate": "0.7.3",
             "gl-matrix": "3.4.3",
             "globalthis": "1.0.3",
-            "jszip": "3.9.1",
-            "pako": "2.0.4",
             "seedrandom": "3.0.5",
             "shader-loader": "1.3.1",
             "shelljs": "0.8.5",
-            "spark-md5": "^3.0.2",
+            "spark-md5": "3.0.2",
             "stream-browserify": "3.0.0",
             "webworker-promise": "0.5.0",
             "worker-loader": "3.0.8",
@@ -5356,29 +5356,6 @@
             "minimist": "^1.2.5"
           }
         },
-        "jszip": {
-          "version": "3.9.1",
-          "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.9.1.tgz",
-          "integrity": "sha512-H9A60xPqJ1CuC4Ka6qxzXZeU8aNmgOeP5IFqwJbQQwtu2EUYxota3LdsiZWplF7Wgd9tkAd0mdu36nceSaPuYw==",
-          "requires": {
-            "lie": "~3.3.0",
-            "pako": "~1.0.2",
-            "readable-stream": "~2.3.6",
-            "set-immediate-shim": "~1.0.1"
-          },
-          "dependencies": {
-            "pako": {
-              "version": "1.0.11",
-              "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-              "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-            }
-          }
-        },
-        "pako": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
-          "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
-        },
         "shelljs": {
           "version": "0.8.5",
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
@@ -5390,21 +5367,20 @@
           }
         },
         "vtk.js": {
-          "version": "24.19.1",
-          "resolved": "https://registry.npmjs.org/vtk.js/-/vtk.js-24.19.1.tgz",
-          "integrity": "sha512-1CZF3Z3D3q/PJxIInP7WQQvFngDYAywt2fZZyZfr7y7WQUPfds7dGXk1Z4J4osujdUZjvS0uIBKTo4Qd3u3kZw==",
+          "version": "25.7.2",
+          "resolved": "https://registry.npmjs.org/vtk.js/-/vtk.js-25.7.2.tgz",
+          "integrity": "sha512-p1ztrxdZVa3vH3H++savxYsu5/RO7fWOT1bt76W+c9w6B0MbWoykGT7iqjKeRNcnAIri6S2ZIT3MXwyUWDQnxQ==",
           "requires": {
             "@babel/runtime": "7.17.9",
             "commander": "9.2.0",
             "d3-scale": "4.0.2",
+            "fflate": "0.7.3",
             "gl-matrix": "3.4.3",
             "globalthis": "1.0.3",
-            "jszip": "3.9.1",
-            "pako": "2.0.4",
             "seedrandom": "3.0.5",
             "shader-loader": "1.3.1",
             "shelljs": "0.8.5",
-            "spark-md5": "^3.0.2",
+            "spark-md5": "3.0.2",
             "stream-browserify": "3.0.0",
             "webworker-promise": "0.5.0",
             "worker-loader": "3.0.8",
@@ -5424,9 +5400,9 @@
           }
         },
         "wslink": {
-          "version": "1.6.6",
-          "resolved": "https://registry.npmjs.org/wslink/-/wslink-1.6.6.tgz",
-          "integrity": "sha512-4gsAnhRBvnfg5uAbk2Q0akwZ4ZQVeDlr97oc/To9kJ3YIxmy4Jh/kMDLzod8+kFvpoj4BbWVr51A9EqlRmknJg==",
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/wslink/-/wslink-1.7.0.tgz",
+          "integrity": "sha512-g+HJvmmZ07+5pfu3cPTl3WPluv0/m0ZQzAMsA+oFu7y7v3j0+NRI1g5YbaAeNBLJv1uppHFp6SOy2Xt+5ohxNA==",
           "peer": true,
           "requires": {
             "json5": "2.2.0"

--- a/examples/itk-vtk-viewer/package.json
+++ b/examples/itk-vtk-viewer/package.json
@@ -14,6 +14,6 @@
   },
   "dependencies": {
     "@kitware/vtk.js": "^19.0.2",
-    "itk-vtk-viewer": "^14.2.1"
+    "itk-vtk-viewer": "^14.9.1"
   }
 }

--- a/examples/itk-vtk-viewer/vite.config.js
+++ b/examples/itk-vtk-viewer/vite.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
           import.meta.url
         )
       ),
-      'itk-viewer-transfer-function-editor': fileURLToPath(
+      'itk-viewer-transfer-function-editor.js': fileURLToPath(
         new URL('../../lib/TransferFunctionEditor.ts', import.meta.url)
       ),
     },

--- a/examples/itk-vtk-viewer/vite.config.js
+++ b/examples/itk-vtk-viewer/vite.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
           import.meta.url
         )
       ),
-      'itk-viewer-transfer-function-editor.js': fileURLToPath(
+      'itk-viewer-transfer-function-editor': fileURLToPath(
         new URL('../../lib/TransferFunctionEditor.ts', import.meta.url)
       ),
     },

--- a/examples/vtk-js/style.css
+++ b/examples/vtk-js/style.css
@@ -12,6 +12,6 @@
 
 #editorHome {
   background-color: lightgray;
-  height: 100px;
+  height: 300px;
   box-sizing: 'border-box';
 }

--- a/lib/PiecewiseUtils.ts
+++ b/lib/PiecewiseUtils.ts
@@ -64,16 +64,16 @@ const CANVAS_HEIGHT = 1
 export const updateColorCanvas = (
   colorTransferFunction: ColorTransferFunction,
   width: number,
+  renderedDataRange: [number, number],
   canvas: HTMLCanvasElement
 ) => {
   const workCanvas = canvas || document.createElement('canvas')
   workCanvas.setAttribute('width', String(width))
   workCanvas.setAttribute('height', String(CANVAS_HEIGHT))
 
-  const [startValue, endValue] = colorTransferFunction.getMappingRange()
   const rgba = colorTransferFunction.getUint8Table(
-    startValue,
-    endValue,
+    renderedDataRange[0],
+    renderedDataRange[1],
     width,
     true
   )


### PR DESCRIPTION
Clips rendering of color function canvas that extends beyond the SVG size.  Before, color canvas would get big when viewBox is small (aka zoomed in) and points were far outside viewBox. Firefox was generating a NS_ERROR_FAILURE error.